### PR TITLE
Add Terraform config for local repo setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Superschedules IAC
+
+This repository contains Terraform configuration for setting up the local development environment. The configuration installs required packages and clones several Git repositories.
+
+## Usage
+
+1. Ensure [Terraform](https://www.terraform.io/) is installed locally.
+2. Initialize and apply the configuration:
+
+```sh
+terraform init
+terraform apply
+```
+
+Terraform will execute commands that:
+
+- Update apt package information and install `rake` and `git`.
+- Clone the following repositories to your home directory:
+  - [dotfiles-1](https://github.com/gkirkpatrick/dotfiles-1)
+  - [superschedules](https://github.com/gkirkpatrick/superschedules)
+  - [superschedules_IAC](https://github.com/gkirkpatrick/superschedules_IAC)
+  - [superschedules_frontend](https://github.com/gkirkpatrick/superschedules_frontend)
+
+Each repository is cloned if it does not already exist. If it is already present, the configuration will run `git pull` to update it.

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
+resource "null_resource" "setup_environment" {
+  provisioner "local-exec" {
+    command = <<EOT
+sudo apt-get update
+sudo apt-get install -y rake git
+
+# Clone dotfiles repository
+if [ ! -d "$HOME/dotfiles-1" ]; then
+  git clone https://github.com/gkirkpatrick/dotfiles-1 "$HOME/dotfiles-1"
+else
+  (cd "$HOME/dotfiles-1" && git pull)
+fi
+
+# Clone superschedules repositories
+if [ ! -d "$HOME/superschedules" ]; then
+  git clone https://github.com/gkirkpatrick/superschedules "$HOME/superschedules"
+else
+  (cd "$HOME/superschedules" && git pull)
+fi
+
+if [ ! -d "$HOME/superschedules_IAC" ]; then
+  git clone https://github.com/gkirkpatrick/superschedules_IAC "$HOME/superschedules_IAC"
+else
+  (cd "$HOME/superschedules_IAC" && git pull)
+fi
+
+if [ ! -d "$HOME/superschedules_frontend" ]; then
+  git clone https://github.com/gkirkpatrick/superschedules_frontend "$HOME/superschedules_frontend"
+else
+  (cd "$HOME/superschedules_frontend" && git pull)
+fi
+EOT
+    interpreter = ["/bin/bash", "-c"]
+  }
+}


### PR DESCRIPTION
## Summary
- add Terraform configuration that installs `rake` and clones the required repositories
- document usage in README

## Testing
- `terraform version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887c76aa0f483338ff57ab7f83a6536