### PR TITLE
Use SSH for GitHub clones and verify key

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ This repository contains Terraform configuration for setting up the local develo
 ## Usage
 
 1. Ensure [Terraform](https://developer.hashicorp.com/terraform/install) is installed locally.
-2. Initialize and apply the configuration:
+2. Ensure you have an SSH key configured with access to GitHub.
+3. Initialize and apply the configuration:
 
 ```sh
 terraform init
@@ -15,7 +16,8 @@ terraform apply
 Terraform will execute commands that:
 
 - Update apt package information and install `rake` and `git`.
-- Clone the following repositories to your home directory:
+- Verify that your SSH key can authenticate with GitHub.
+- Clone the following repositories to your home directory using SSH:
   - [dotfiles-1](https://github.com/gkirkpatrick/dotfiles-1)
   - [superschedules](https://github.com/gkirkpatrick/superschedules)
   - [superschedules_IAC](https://github.com/gkirkpatrick/superschedules_IAC)

--- a/main.tf
+++ b/main.tf
@@ -4,32 +4,38 @@ terraform {
 
 resource "null_resource" "setup_environment" {
   provisioner "local-exec" {
-    command = <<EOT
+    command     = <<EOT
 sudo apt-get update
 sudo apt-get install -y rake git
 
+# Verify GitHub SSH access
+if ! ssh -o StrictHostKeyChecking=no -o BatchMode=yes -T git@github.com 2>&1 | grep -q "successfully authenticated"; then
+  echo "Error: could not authenticate to GitHub via SSH." >&2
+  exit 1
+fi
+
 # Clone dotfiles repository
 if [ ! -d "$HOME/dotfiles-1" ]; then
-  git clone https://github.com/gkirkpatrick/dotfiles-1 "$HOME/dotfiles-1"
+  git clone git@github.com:gkirkpatrick/dotfiles-1 "$HOME/dotfiles-1"
 else
   (cd "$HOME/dotfiles-1" && git pull)
 fi
 
 # Clone superschedules repositories
 if [ ! -d "$HOME/superschedules" ]; then
-  git clone https://github.com/gkirkpatrick/superschedules "$HOME/superschedules"
+  git clone git@github.com:gkirkpatrick/superschedules "$HOME/superschedules"
 else
   (cd "$HOME/superschedules" && git pull)
 fi
 
 if [ ! -d "$HOME/superschedules_IAC" ]; then
-  git clone https://github.com/gkirkpatrick/superschedules_IAC "$HOME/superschedules_IAC"
+  git clone git@github.com:gkirkpatrick/superschedules_IAC "$HOME/superschedules_IAC"
 else
   (cd "$HOME/superschedules_IAC" && git pull)
 fi
 
 if [ ! -d "$HOME/superschedules_frontend" ]; then
-  git clone https://github.com/gkirkpatrick/superschedules_frontend "$HOME/superschedules_frontend"
+  git clone git@github.com:gkirkpatrick/superschedules_frontend "$HOME/superschedules_frontend"
 else
   (cd "$HOME/superschedules_frontend" && git pull)
 fi


### PR DESCRIPTION
## Summary
- Ensure GitHub SSH authentication succeeds before running setup
- Switch all repository clones to SSH URLs and document SSH requirement

## Testing
- `terraform fmt -check`
- `terraform init` *(fails: could not connect to registry.terraform.io)*
- `terraform validate` *(fails: missing required provider)*

------
https://chatgpt.com/codex/tasks/task_e_68921edb18808333842e4702b7f41ba9