### PR TITLE
Split repository setup scripts and add AWS dev instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Superschedules IAC
 
-This repository contains Terraform configuration for the Superschedules project. The Terraform code lives under the `terraform/` directory and is organized into environments for development and production. The development configuration installs required packages, clones several Git repositories, and performs basic setup for each project.
+This repository contains Terraform configuration for the Superschedules project. The Terraform code lives under the `terraform/`
+directory and is organized into environments for development and production. The development configuration installs required packages,
+clones several Git repositories via separate setup scripts, and begins provisioning an AWS EC2 instance for the dev environment.
 
 ## Usage
 
@@ -17,13 +19,13 @@ terraform apply
 Terraform runs two resources:
 
 - **setup_once** updates apt package information and installs base packages: `rake`, `git`, `python3-pip`, `python3-venv`, `curl`, and `build-essential`. This runs only once unless the resource is tainted.
-- **setup_environment** runs on every apply. It verifies that your SSH key can authenticate with GitHub, clones or updates repositories, installs Node.js 20 via NVM, and installs frontend dependencies.
+- **setup_environment** runs on every apply. It verifies that your SSH key can authenticate with GitHub and delegates repository setup to scripts in `scripts/`.
 
-The following repositories are cloned to your home directory using SSH:
+The following setup scripts under `terraform/dev/scripts` clone or update repositories and perform per-project initialization:
 
-- [dotfiles-1](https://github.com/gkirkpatrick/dotfiles-1) and run `rake install` within it.
-- [superschedules](https://github.com/gkirkpatrick/superschedules), create a `schedules_dev` virtual environment, and install dependencies from `requirements.txt`.
-- [superschedules_IAC](https://github.com/gkirkpatrick/superschedules_IAC).
-- [superschedules_frontend](https://github.com/gkirkpatrick/superschedules_frontend) and install npm dependencies.
+- `setup_dotfiles.sh` for [dotfiles-1](https://github.com/gkirkpatrick/dotfiles-1).
+- `setup_superschedules.sh` for [superschedules](https://github.com/gkirkpatrick/superschedules) and its Python virtual environment.
+- `setup_superschedules_IAC.sh` for [superschedules_IAC](https://github.com/gkirkpatrick/superschedules_IAC).
+- `setup_superschedules_frontend.sh` for [superschedules_frontend](https://github.com/gkirkpatrick/superschedules_frontend), including Node.js 20 via NVM and npm dependencies.
 
-Each repository is cloned if it does not already exist. If it is already present, the configuration will run `git pull` to update it before performing the setup steps.
+An `aws_instance` resource named `dev` has been added as a starting point for hosting the development environment on AWS. Provide the `ssh_key_name` variable to supply your existing key pair.

--- a/terraform/dev/aws_instance.tf
+++ b/terraform/dev/aws_instance.tf
@@ -1,0 +1,42 @@
+provider "aws" {
+  region = var.aws_region
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+}
+
+resource "aws_security_group" "dev" {
+  name        = "superschedules-dev-sg"
+  description = "Allow SSH access"
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "dev" {
+  ami                    = data.aws_ami.ubuntu.id
+  instance_type          = var.dev_instance_type
+  key_name               = var.ssh_key_name
+  vpc_security_group_ids = [aws_security_group.dev.id]
+
+  tags = {
+    Name = "superschedules-dev"
+  }
+}

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -21,52 +21,10 @@ if ! ssh -o StrictHostKeyChecking=no -o BatchMode=yes -T git@github.com 2>&1 | g
   exit 1
 fi
 
-# Clone dotfiles repository
-if [ ! -d "$HOME/dotfiles-1" ]; then
-  git clone git@github.com:gkirkpatrick/dotfiles-1 "$HOME/dotfiles-1"
-else
-  (cd "$HOME/dotfiles-1" && git pull)
-fi
-(cd "$HOME/dotfiles-1" && rake install)
-
-# Clone superschedules repository
-if [ ! -d "$HOME/superschedules" ]; then
-  git clone git@github.com:gkirkpatrick/superschedules "$HOME/superschedules"
-else
-  (cd "$HOME/superschedules" && git pull)
-fi
-if [ ! -d "$HOME/superschedules/schedules_dev" ]; then
-  python3 -m venv "$HOME/superschedules/schedules_dev"
-fi
-source "$HOME/superschedules/schedules_dev/bin/activate"
-pip install -r "$HOME/superschedules/requirements.txt"
-deactivate
-
-if [ ! -d "$HOME/superschedules_IAC" ]; then
-  git clone git@github.com:gkirkpatrick/superschedules_IAC "$HOME/superschedules_IAC"
-else
-  (cd "$HOME/superschedules_IAC" && git pull)
-fi
-
-if [ ! -d "$HOME/superschedules_frontend" ]; then
-  git clone git@github.com:gkirkpatrick/superschedules_frontend "$HOME/superschedules_frontend"
-else
-  (cd "$HOME/superschedules_frontend" && git pull)
-fi
-
-# Install NVM and Node.js 20
-export NVM_DIR="$HOME/.nvm"
-if [ ! -d "$NVM_DIR" ]; then
-  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
-fi
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
-nvm install 20
-nvm alias default 20
-
-# Install frontend dependencies
-cd "$HOME/superschedules_frontend"
-npm install
+${path.module}/scripts/setup_dotfiles.sh
+${path.module}/scripts/setup_superschedules.sh
+${path.module}/scripts/setup_superschedules_IAC.sh
+${path.module}/scripts/setup_superschedules_frontend.sh
 EOT
     interpreter = ["/bin/bash", "-c"]
   }
@@ -79,4 +37,3 @@ EOT
     null_resource.setup_once
   ]
 }
-

--- a/terraform/dev/outputs.tf
+++ b/terraform/dev/outputs.tf
@@ -1,0 +1,4 @@
+output "dev_instance_public_ip" {
+  description = "Public IP of the dev EC2 instance"
+  value       = aws_instance.dev.public_ip
+}

--- a/terraform/dev/scripts/setup_dotfiles.sh
+++ b/terraform/dev/scripts/setup_dotfiles.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+REPO_DIR="$HOME/dotfiles-1"
+if [ ! -d "$REPO_DIR" ]; then
+  git clone git@github.com:gkirkpatrick/dotfiles-1 "$REPO_DIR"
+else
+  (cd "$REPO_DIR" && git pull)
+fi
+(cd "$REPO_DIR" && rake install)

--- a/terraform/dev/scripts/setup_superschedules.sh
+++ b/terraform/dev/scripts/setup_superschedules.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+REPO_DIR="$HOME/superschedules"
+if [ ! -d "$REPO_DIR" ]; then
+  git clone git@github.com:gkirkpatrick/superschedules "$REPO_DIR"
+else
+  (cd "$REPO_DIR" && git pull)
+fi
+if [ ! -d "$REPO_DIR/schedules_dev" ]; then
+  python3 -m venv "$REPO_DIR/schedules_dev"
+fi
+source "$REPO_DIR/schedules_dev/bin/activate"
+pip install -r "$REPO_DIR/requirements.txt"
+deactivate

--- a/terraform/dev/scripts/setup_superschedules_IAC.sh
+++ b/terraform/dev/scripts/setup_superschedules_IAC.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+REPO_DIR="$HOME/superschedules_IAC"
+if [ ! -d "$REPO_DIR" ]; then
+  git clone git@github.com:gkirkpatrick/superschedules_IAC "$REPO_DIR"
+else
+  (cd "$REPO_DIR" && git pull)
+fi

--- a/terraform/dev/scripts/setup_superschedules_frontend.sh
+++ b/terraform/dev/scripts/setup_superschedules_frontend.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+REPO_DIR="$HOME/superschedules_frontend"
+if [ ! -d "$REPO_DIR" ]; then
+  git clone git@github.com:gkirkpatrick/superschedules_frontend "$REPO_DIR"
+else
+  (cd "$REPO_DIR" && git pull)
+fi
+
+# Install NVM and Node.js 20
+export NVM_DIR="$HOME/.nvm"
+if [ ! -d "$NVM_DIR" ]; then
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+fi
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+nvm install 20
+nvm alias default 20
+
+# Install frontend dependencies
+cd "$REPO_DIR"
+npm install

--- a/terraform/dev/variables.tf
+++ b/terraform/dev/variables.tf
@@ -1,0 +1,16 @@
+variable "aws_region" {
+  description = "AWS region for dev resources"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "dev_instance_type" {
+  description = "EC2 instance type for dev"
+  type        = string
+  default     = "t3.micro"
+}
+
+variable "ssh_key_name" {
+  description = "Name of the existing AWS key pair for SSH access"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- Move each repository setup into dedicated shell scripts and invoke them from Terraform
- Begin AWS dev environment by adding EC2 instance, security group and variables
- Document new script layout and AWS dev instance in README

## Testing
- `terraform fmt -recursive`
- `terraform -chdir=terraform/dev init -backend=false` *(fails: could not connect to registry.terraform.io)*
- `terraform -chdir=terraform/dev validate` *(fails: missing required provider)*

------
https://chatgpt.com/codex/tasks/task_e_6892605183248333a13a911fae1a866f