### PR TITLE
Add local and prod deployment options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: dev-ec2 dev-local prod-deploy
+
+dev-ec2:
+	terraform -chdir=terraform/dev init
+	terraform -chdir=terraform/dev apply
+
+dev-local:
+	terraform -chdir=terraform/local init
+	terraform -chdir=terraform/local apply
+
+prod-deploy:
+	terraform -chdir=terraform/prod init
+	terraform -chdir=terraform/prod apply

--- a/README.md
+++ b/README.md
@@ -1,22 +1,28 @@
 # Superschedules IAC
 
 This repository contains Terraform configuration for the Superschedules project. The Terraform code lives under the `terraform/`
-directory and is organized into environments for development and production. The development configuration installs required packages,
-clones several Git repositories via separate setup scripts, and begins provisioning an AWS EC2 instance for the dev environment.
+directory and is organized into environments for development (both EC2 and local) and production. The development configuration
+installs required packages, clones several Git repositories via separate setup scripts, and can optionally provision an AWS EC2
+instance for the dev environment.
 
 ## Usage
 
 1. Ensure [Terraform](https://developer.hashicorp.com/terraform/install) is installed locally.
 2. Ensure you have an SSH key configured with access to GitHub.
-3. Change into the development configuration directory and initialize/apply:
+3. Choose one of the following targets:
 
 ```sh
-cd terraform/dev
-terraform init
-terraform apply
+# Provision a dev EC2 instance and run setup scripts
+make dev-ec2
+
+# Run setup scripts locally without creating an EC2 instance
+make dev-local
+
+# Provision the production EC2 instance
+make prod-deploy
 ```
 
-Terraform runs two resources:
+The development configuration uses two resources:
 
 - **setup_once** updates apt package information and installs base packages: `rake`, `git`, `python3-pip`, `python3-venv`, `curl`, and `build-essential`. This runs only once unless the resource is tainted.
 - **setup_environment** runs on every apply. It verifies that your SSH key can authenticate with GitHub and delegates repository setup to scripts in `scripts/`.
@@ -28,4 +34,4 @@ The following setup scripts under `terraform/dev/scripts` clone or update reposi
 - `setup_superschedules_IAC.sh` for [superschedules_IAC](https://github.com/gkirkpatrick/superschedules_IAC).
 - `setup_superschedules_frontend.sh` for [superschedules_frontend](https://github.com/gkirkpatrick/superschedules_frontend), including Node.js 20 via NVM and npm dependencies.
 
-An `aws_instance` resource named `dev` has been added as a starting point for hosting the development environment on AWS. Provide the `ssh_key_name` variable to supply your existing key pair.
+An `aws_instance` resource named `dev` and a similar `prod` instance have been added as starting points for hosting the environments on AWS. Provide the `ssh_key_name` variable to supply your existing key pair.

--- a/terraform/local/main.tf
+++ b/terraform/local/main.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
+resource "null_resource" "setup_once" {
+  provisioner "local-exec" {
+    command     = <<EOT
+sudo apt-get update
+sudo apt-get install -y rake git python3-pip python3-venv curl build-essential
+EOT
+    interpreter = ["/bin/bash", "-c"]
+  }
+}
+
+resource "null_resource" "setup_environment" {
+  provisioner "local-exec" {
+    command     = <<EOT
+# Verify GitHub SSH access
+if ! ssh -o StrictHostKeyChecking=no -o BatchMode=yes -T git@github.com 2>&1 | grep -q "successfully authenticated"; then
+  echo "Error: could not authenticate to GitHub via SSH." >&2
+  exit 1
+fi
+
+${path.module}/../dev/scripts/setup_dotfiles.sh
+${path.module}/../dev/scripts/setup_superschedules.sh
+${path.module}/../dev/scripts/setup_superschedules_IAC.sh
+${path.module}/../dev/scripts/setup_superschedules_frontend.sh
+EOT
+    interpreter = ["/bin/bash", "-c"]
+  }
+
+  triggers = {
+    always_run = timestamp()
+  }
+
+  depends_on = [
+    null_resource.setup_once
+  ]
+}

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -1,1 +1,46 @@
-// Production infrastructure placeholder
+terraform {
+  required_version = ">= 0.12"
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"]
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+}
+
+resource "aws_security_group" "prod" {
+  name        = "superschedules-prod-sg"
+  description = "Allow SSH access"
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "prod" {
+  ami                    = data.aws_ami.ubuntu.id
+  instance_type          = var.prod_instance_type
+  key_name               = var.ssh_key_name
+  vpc_security_group_ids = [aws_security_group.prod.id]
+
+  tags = {
+    Name = "superschedules-prod"
+  }
+}

--- a/terraform/prod/outputs.tf
+++ b/terraform/prod/outputs.tf
@@ -1,0 +1,4 @@
+output "prod_instance_public_ip" {
+  description = "Public IP of the prod EC2 instance"
+  value       = aws_instance.prod.public_ip
+}

--- a/terraform/prod/variables.tf
+++ b/terraform/prod/variables.tf
@@ -1,0 +1,16 @@
+variable "aws_region" {
+  description = "AWS region for prod resources"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "prod_instance_type" {
+  description = "EC2 instance type for prod"
+  type        = string
+  default     = "t3.small"
+}
+
+variable "ssh_key_name" {
+  description = "Name of the existing AWS key pair for SSH access"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- add Makefile with targets for dev EC2, local setup, and prod deploy
- add Terraform configs for local setup and production EC2 instance
- document the three run modes

## Testing
- `terraform -chdir=superschedules_IAC/terraform/local init -backend=false` *(fails: could not connect to registry.terraform.io)*
- `terraform -chdir=superschedules_IAC/terraform/prod init -backend=false` *(fails: could not connect to registry.terraform.io)*


------
https://chatgpt.com/codex/tasks/task_e_689281b6d0e883338c51ac9967133bce