### PR TITLE
Support superschedules_collector repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,5 +33,6 @@ The following setup scripts under `terraform/dev/scripts` clone or update reposi
 - `setup_superschedules.sh` for [superschedules](https://github.com/gkirkpatrick/superschedules) and its Python virtual environment.
 - `setup_superschedules_IAC.sh` for [superschedules_IAC](https://github.com/gkirkpatrick/superschedules_IAC).
 - `setup_superschedules_frontend.sh` for [superschedules_frontend](https://github.com/gkirkpatrick/superschedules_frontend), including Node.js 20 via NVM and npm dependencies.
+- `setup_superschedules_collector.sh` for [superschedules_collector](https://github.com/gkirkpatrick/superschedules_collector) and its Python virtual environment.
 
 An `aws_instance` resource named `dev` and a similar `prod` instance have been added as starting points for hosting the environments on AWS. Provide the `ssh_key_name` variable to supply your existing key pair.

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -25,6 +25,7 @@ ${path.module}/scripts/setup_dotfiles.sh
 ${path.module}/scripts/setup_superschedules.sh
 ${path.module}/scripts/setup_superschedules_IAC.sh
 ${path.module}/scripts/setup_superschedules_frontend.sh
+${path.module}/scripts/setup_superschedules_collector.sh
 EOT
     interpreter = ["/bin/bash", "-c"]
   }

--- a/terraform/dev/scripts/setup_superschedules_collector.sh
+++ b/terraform/dev/scripts/setup_superschedules_collector.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+REPO_DIR="$HOME/superschedules_collector"
+if [ ! -d "$REPO_DIR" ]; then
+  git clone git@github.com:gkirkpatrick/superschedules_collector "$REPO_DIR"
+else
+  (cd "$REPO_DIR" && git pull)
+fi
+if [ ! -d "$REPO_DIR/collector_dev" ]; then
+  python3 -m venv "$REPO_DIR/collector_dev"
+fi
+source "$REPO_DIR/collector_dev/bin/activate"
+pip install -r "$REPO_DIR/requirements.txt"
+deactivate


### PR DESCRIPTION
## Summary
- add setup script for superschedules_collector
- run collector setup in dev Terraform configuration
- document collector setup script in README

## Testing
- `bash -n terraform/dev/scripts/setup_superschedules_collector.sh`
- `terraform -chdir=terraform/dev fmt -check`
- `terraform -chdir=terraform/dev validate` *(fails: Missing required provider; run `terraform init` to install)*
- `terraform -chdir=terraform/dev init -backend=false` *(fails: could not connect to registry.terraform.io)*

------
https://chatgpt.com/codex/tasks/task_e_6893978942608333aa626d9a30dd95ef