### PR TITLE
Include collector repo in local setup

### DIFF
--- a/terraform/local/main.tf
+++ b/terraform/local/main.tf
@@ -25,6 +25,7 @@ ${path.module}/../dev/scripts/setup_dotfiles.sh
 ${path.module}/../dev/scripts/setup_superschedules.sh
 ${path.module}/../dev/scripts/setup_superschedules_IAC.sh
 ${path.module}/../dev/scripts/setup_superschedules_frontend.sh
+${path.module}/../dev/scripts/setup_superschedules_collector.sh
 EOT
     interpreter = ["/bin/bash", "-c"]
   }


### PR DESCRIPTION
## Summary
- add collector setup script to local Terraform configuration so local dev environment clones superschedules_collector

## Testing
- `terraform -chdir=terraform/local fmt`
- `terraform -chdir=terraform/local init` (fails: could not connect to registry.terraform.io)
- `terraform -chdir=terraform/local validate` (fails: missing required provider)

------
https://chatgpt.com/codex/tasks/task_e_68939f995020833392abd4ba01ac3c4d