### PR TITLE
Support macOS in local dev setup

### DIFF
--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -5,8 +5,19 @@ terraform {
 resource "null_resource" "setup_once" {
   provisioner "local-exec" {
     command     = <<EOT
-sudo apt-get update
-sudo apt-get install -y rake git python3-pip python3-venv curl build-essential
+if [[ "$(uname)" == "Darwin" ]]; then
+  # Ensure Homebrew is installed
+  if ! command -v brew >/dev/null 2>&1; then
+    echo "Installing Homebrew" >&2
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    eval "$($(test -x /opt/homebrew/bin/brew && echo /opt/homebrew/bin/brew || echo /usr/local/bin/brew) shellenv)"
+  fi
+  brew update
+  brew install git curl rake python
+else
+  sudo apt-get update
+  sudo apt-get install -y rake git python3-pip python3-venv curl build-essential
+fi
 EOT
     interpreter = ["/bin/bash", "-c"]
   }

--- a/terraform/local/main.tf
+++ b/terraform/local/main.tf
@@ -5,8 +5,19 @@ terraform {
 resource "null_resource" "setup_once" {
   provisioner "local-exec" {
     command     = <<EOT
-sudo apt-get update
-sudo apt-get install -y rake git python3-pip python3-venv curl build-essential
+if [[ "$(uname)" == "Darwin" ]]; then
+  # Ensure Homebrew is installed
+  if ! command -v brew >/dev/null 2>&1; then
+    echo "Installing Homebrew" >&2
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    eval "$($(test -x /opt/homebrew/bin/brew && echo /opt/homebrew/bin/brew || echo /usr/local/bin/brew) shellenv)"
+  fi
+  brew update
+  brew install git curl rake python
+else
+  sudo apt-get update
+  sudo apt-get install -y rake git python3-pip python3-venv curl build-essential
+fi
 EOT
     interpreter = ["/bin/bash", "-c"]
   }


### PR DESCRIPTION
## Summary
- allow local and dev Terraform modules to install dependencies with Homebrew on macOS
- ensure a newer Python is installed on macOS while retaining apt-get flow on Linux

## Testing
- `terraform -chdir=terraform/local fmt`
- `terraform -chdir=terraform/dev fmt`
- `terraform -chdir=terraform/local init -backend=false` *(fails: could not connect to registry.terraform.io)*
- `terraform -chdir=terraform/dev init -backend=false` *(fails: could not connect to registry.terraform.io)*

------
https://chatgpt.com/codex/tasks/task_e_68961c07a2f083339ece2dc78739ee3d