### PR TITLE
Avoid installing rake separately in Terraform setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ make prod-deploy
 
 The development configuration uses two resources:
 
-- **setup_once** updates apt package information and installs base packages: `rake`, `git`, `python3-pip`, `python3-venv`, `curl`, and `build-essential`. This runs only once unless the resource is tainted.
+- **setup_once** updates apt package information and installs base packages: `git`, `python3-pip`, `python3-venv`, `curl`, and `build-essential`. This runs only once unless the resource is tainted.
 - **setup_environment** runs on every apply. It verifies that your SSH key can authenticate with GitHub and delegates repository setup to scripts in `scripts/`.
 
 The following setup scripts under `terraform/dev/scripts` clone or update repositories and perform per-project initialization:

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -13,10 +13,10 @@ if [[ "$(uname)" == "Darwin" ]]; then
     eval "$($(test -x /opt/homebrew/bin/brew && echo /opt/homebrew/bin/brew || echo /usr/local/bin/brew) shellenv)"
   fi
   brew update
-  brew install git curl rake python
+  brew install git curl python
 else
   sudo apt-get update
-  sudo apt-get install -y rake git python3-pip python3-venv curl build-essential
+  sudo apt-get install -y git python3-pip python3-venv curl build-essential
 fi
 EOT
     interpreter = ["/bin/bash", "-c"]

--- a/terraform/local/main.tf
+++ b/terraform/local/main.tf
@@ -13,10 +13,10 @@ if [[ "$(uname)" == "Darwin" ]]; then
     eval "$($(test -x /opt/homebrew/bin/brew && echo /opt/homebrew/bin/brew || echo /usr/local/bin/brew) shellenv)"
   fi
   brew update
-  brew install git curl rake python
+  brew install git curl python
 else
   sudo apt-get update
-  sudo apt-get install -y rake git python3-pip python3-venv curl build-essential
+  sudo apt-get install -y git python3-pip python3-venv curl build-essential
 fi
 EOT
     interpreter = ["/bin/bash", "-c"]


### PR DESCRIPTION
## Summary
- drop rake from homebrew and apt package installs
- update docs to reflect that rake is no longer installed

## Testing
- `terraform fmt -recursive`
- `terraform -chdir=terraform/dev init -backend=false` *(fails: Failed to query available provider packages: could not connect to registry.terraform.io)*
- `terraform -chdir=terraform/local init -backend=false` *(fails: Failed to query available provider packages: could not connect to registry.terraform.io)*

------
https://chatgpt.com/codex/tasks/task_e_6896230c1a048333b9d4117d1eaa111a