### PR TITLE
Use install script for dotfiles setup

### DIFF
--- a/terraform/dev/scripts/setup_dotfiles.sh
+++ b/terraform/dev/scripts/setup_dotfiles.sh
@@ -6,4 +6,4 @@ if [ ! -d "$REPO_DIR" ]; then
 else
   (cd "$REPO_DIR" && git pull)
 fi
-(cd "$REPO_DIR" && rake install)
+(cd "$REPO_DIR" && ./install.sh)


### PR DESCRIPTION
## Summary
- run new install.sh in dotfiles setup script instead of `rake install`

## Testing
- `bash -n terraform/dev/scripts/setup_dotfiles.sh`
- `terraform -chdir=terraform/dev fmt -check` *(fails: command not found)*
- `apt-get install -y terraform` *(fails: Unable to locate package terraform)*

------
https://chatgpt.com/codex/tasks/task_e_689625938dd483339b60a728593952b8