### PR TITLE
Ensure Node tools available after local frontend setup

### DIFF
--- a/terraform/dev/scripts/setup_superschedules_frontend.sh
+++ b/terraform/dev/scripts/setup_superschedules_frontend.sh
@@ -16,6 +16,25 @@ export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
 nvm install 20
 nvm alias default 20
+nvm use 20
+
+# Ensure Homebrew is available in login shells
+if command -v brew >/dev/null 2>&1; then
+  BREW_PREFIX="$(brew --prefix)"
+  BREW_SHELLENV="eval \"\$(${BREW_PREFIX}/bin/brew shellenv)\""
+  if ! grep -Fq "$BREW_SHELLENV" "$HOME/.zprofile" 2>/dev/null; then
+    echo "$BREW_SHELLENV" >> "$HOME/.zprofile"
+  fi
+  eval "$(${BREW_PREFIX}/bin/brew shellenv)"
+fi
+
+# Ensure NVM is initialized for new shells
+if ! grep -q 'export NVM_DIR="$HOME/.nvm"' "$HOME/.zshrc" 2>/dev/null; then
+  cat >> "$HOME/.zshrc" <<'EOF'
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+EOF
+fi
 
 # Install frontend dependencies
 cd "$REPO_DIR"


### PR DESCRIPTION
## Summary
- initialize Homebrew in login shells and persist its path
- add NVM initialization to `.zshrc` so `npm` is available in new shells

## Testing
- `bash -n terraform/dev/scripts/setup_superschedules_frontend.sh`
- `shellcheck terraform/dev/scripts/setup_superschedules_frontend.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689628e714d48333ba0e3644e423d461