### PR TITLE
Run migrations after superschedules setup

### DIFF
--- a/terraform/dev/scripts/setup_superschedules.sh
+++ b/terraform/dev/scripts/setup_superschedules.sh
@@ -11,4 +11,7 @@ if [ ! -d "$REPO_DIR/schedules_dev" ]; then
 fi
 source "$REPO_DIR/schedules_dev/bin/activate"
 pip install -r "$REPO_DIR/requirements.txt"
+
+# Run database migrations to keep the schema up to date
+python "$REPO_DIR/manage.py" migrate
 deactivate


### PR DESCRIPTION
## Summary
- Run Django migrations after installing superschedules dependencies to keep DB schema current

## Testing
- `bash -n terraform/dev/scripts/setup_superschedules.sh`
- `shellcheck -x terraform/dev/scripts/setup_superschedules.sh`


------
https://chatgpt.com/codex/tasks/task_e_689648f20bf48333bb3c224a5ff01033