### PR TITLE
Install ollama and gemma2 model during local build

### DIFF
--- a/terraform/local/main.tf
+++ b/terraform/local/main.tf
@@ -18,6 +18,10 @@ else
   sudo apt-get update
   sudo apt-get install -y git python3-pip python3-venv curl build-essential
 fi
+
+# Install Ollama and the Gemma2 model
+curl -fsSL https://ollama.com/install.sh | sh
+ollama pull gemma2
 EOT
     interpreter = ["/bin/bash", "-c"]
   }


### PR DESCRIPTION
## Summary
- Ensure local build script installs Ollama and pulls the Gemma2 model

## Testing
- `terraform -chdir=superschedules_IAC/terraform/local fmt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a49d642b948333b746a9002a729925