### PR TITLE
Document Ollama setup and pin Gemma model

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ The development configuration uses two resources:
 - **setup_once** updates apt package information and installs base packages: `git`, `python3-pip`, `python3-venv`, `curl`, and `build-essential`. This runs only once unless the resource is tainted.
 - **setup_environment** runs on every apply. It verifies that your SSH key can authenticate with GitHub and delegates repository setup to scripts in `scripts/`.
 
+When run locally, the configuration also installs [Ollama](https://ollama.com) and pulls the `gemma2:latest` model.
+
 The following setup scripts under `terraform/dev/scripts` clone or update repositories and perform per-project initialization:
 
 - `setup_dotfiles.sh` for [dotfiles-1](https://github.com/gkirkpatrick/dotfiles-1).

--- a/terraform/local/main.tf
+++ b/terraform/local/main.tf
@@ -19,9 +19,9 @@ else
   sudo apt-get install -y git python3-pip python3-venv curl build-essential
 fi
 
-# Install Ollama and the Gemma2 model
-curl -fsSL https://ollama.com/install.sh | sh
-ollama pull gemma2
+  # Install Ollama and the Gemma2 model (gemma2:latest)
+  curl -fsSL https://ollama.com/install.sh | sh
+  ollama pull gemma2:latest
 EOT
     interpreter = ["/bin/bash", "-c"]
   }


### PR DESCRIPTION
## Summary
- document that local setup installs Ollama and pulls the gemma2:latest model
- ensure local Terraform config pulls gemma2:latest

## Testing
- `terraform -chdir=terraform/local fmt`
- `terraform -chdir=terraform/local init` *(fails: could not connect to registry.terraform.io)*

------
https://chatgpt.com/codex/tasks/task_e_68a4abb4a2a483338fbaed6208ff5af6