### PR TITLE
feat: make dotfile setup optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
 .PHONY: dev-ec2 dev-local prod-deploy
 
+INSTALL_DOTFILES ?= false
+
 dev-ec2:
-	terraform -chdir=terraform/dev init
-	terraform -chdir=terraform/dev apply
+        terraform -chdir=terraform/dev init
+        terraform -chdir=terraform/dev apply -var "install_dotfiles=$(INSTALL_DOTFILES)"
 
 dev-local:
-	terraform -chdir=terraform/local init
-	terraform -chdir=terraform/local apply
+        terraform -chdir=terraform/local init
+        terraform -chdir=terraform/local apply -var "install_dotfiles=$(INSTALL_DOTFILES)"
 
 prod-deploy:
-	terraform -chdir=terraform/prod init
-	terraform -chdir=terraform/prod apply
+        terraform -chdir=terraform/prod init
+        terraform -chdir=terraform/prod apply

--- a/README.md
+++ b/README.md
@@ -9,14 +9,21 @@ instance for the dev environment.
 
 1. Ensure [Terraform](https://developer.hashicorp.com/terraform/install) is installed locally.
 2. Ensure you have an SSH key configured with access to GitHub.
-3. Choose one of the following targets:
+3. (Optional) Set `INSTALL_DOTFILES=true` to clone and install your dotfiles.
+4. Choose one of the following targets:
 
 ```sh
 # Provision a dev EC2 instance and run setup scripts
 make dev-ec2
 
+# Provision a dev EC2 instance and install dotfiles
+make dev-ec2 INSTALL_DOTFILES=true
+
 # Run setup scripts locally without creating an EC2 instance
 make dev-local
+
+# Run setup scripts locally and install dotfiles
+make dev-local INSTALL_DOTFILES=true
 
 # Provision the production EC2 instance
 make prod-deploy

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -32,7 +32,9 @@ if ! ssh -o StrictHostKeyChecking=no -o BatchMode=yes -T git@github.com 2>&1 | g
   exit 1
 fi
 
-${path.module}/scripts/setup_dotfiles.sh
+%{if var.install_dotfiles}
+${path.module}/scripts/setup_dotfiles.sh --install-dot-files
+%{endif}
 ${path.module}/scripts/setup_superschedules.sh
 ${path.module}/scripts/setup_superschedules_IAC.sh
 ${path.module}/scripts/setup_superschedules_frontend.sh

--- a/terraform/dev/scripts/setup_dotfiles.sh
+++ b/terraform/dev/scripts/setup_dotfiles.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 set -e
+
+if [[ "${1:-}" != "--install-dot-files" ]]; then
+  echo "Dotfile installation skipped. Pass --install-dot-files to enable." >&2
+  exit 0
+fi
+
 REPO_DIR="$HOME/dotfiles-1"
 if [ ! -d "$REPO_DIR" ]; then
   git clone git@github.com:gkirkpatrick/dotfiles-1 "$REPO_DIR"

--- a/terraform/dev/variables.tf
+++ b/terraform/dev/variables.tf
@@ -14,3 +14,9 @@ variable "ssh_key_name" {
   description = "Name of the existing AWS key pair for SSH access"
   type        = string
 }
+
+variable "install_dotfiles" {
+  description = "Set to true to install developer dotfiles"
+  type        = bool
+  default     = false
+}

--- a/terraform/local/main.tf
+++ b/terraform/local/main.tf
@@ -36,7 +36,9 @@ if ! ssh -o StrictHostKeyChecking=no -o BatchMode=yes -T git@github.com 2>&1 | g
   exit 1
 fi
 
-${path.module}/../dev/scripts/setup_dotfiles.sh
+%{if var.install_dotfiles}
+${path.module}/../dev/scripts/setup_dotfiles.sh --install-dot-files
+%{endif}
 ${path.module}/../dev/scripts/setup_superschedules.sh
 ${path.module}/../dev/scripts/setup_superschedules_IAC.sh
 ${path.module}/../dev/scripts/setup_superschedules_frontend.sh

--- a/terraform/local/variables.tf
+++ b/terraform/local/variables.tf
@@ -1,0 +1,5 @@
+variable "install_dotfiles" {
+  description = "Set to true to install developer dotfiles"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Summary
- allow Terraform dev/local configs to install dotfiles only when requested
- expose INSTALL_DOTFILES flag via Makefile and document usage

## Testing
- `terraform -chdir=terraform/dev fmt -check`
- `terraform -chdir=terraform/dev init -backend=false` *(fails: could not connect to registry.terraform.io)*
- `terraform -chdir=terraform/local fmt -check`
- `terraform -chdir=terraform/local init -backend=false` *(fails: could not connect to registry.terraform.io)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a8d2e61c408333a54db5d1d956d728